### PR TITLE
security: fix H1, H2, H3 — CSRF refresh, header injection, API error leak

### DIFF
--- a/helloAssoImporter/templates/helloAssoImporter/event_forms.html
+++ b/helloAssoImporter/templates/helloAssoImporter/event_forms.html
@@ -6,7 +6,10 @@
 <style>.sortable { cursor: pointer; }</style>
 <div style="display:flex; align-items:center; gap:1rem; margin-bottom:1.5rem;">
     <h1 style="margin-bottom:0;">Liste des sorties</h1>
-    <a href="{% url 'inscriptions-refresh' %}" class="btn btn-primary">Rafraîchir</a>
+    <form method="post" action="{% url 'inscriptions-refresh' %}" style="display:inline;">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-primary">Rafraîchir</button>
+    </form>
     <a href="{% url 'event-form-create' %}" class="btn btn-secondary">+ Créer une sortie</a>
 </div>
 

--- a/helloAssoImporter/templates/helloAssoImporter/membership_forms.html
+++ b/helloAssoImporter/templates/helloAssoImporter/membership_forms.html
@@ -4,7 +4,10 @@
 {% block saison_content %}
 <div style="display:flex; align-items:center; gap:1rem; margin-bottom:1.5rem;">
     <h1 style="margin-bottom:0;">Formulaires d'inscription</h1>
-    <a href="{% url 'saison-refresh' %}" class="btn btn-primary">Rafraîchir</a>
+    <form method="post" action="{% url 'saison-refresh' %}" style="display:inline;">
+        {% csrf_token %}
+        <button type="submit" class="btn btn-primary">Rafraîchir</button>
+    </form>
 </div>
 
 {% if membership_forms %}

--- a/helloAssoImporter/views.py
+++ b/helloAssoImporter/views.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import time
+from urllib.parse import quote
 from itertools import groupby as itertools_groupby
 from django import forms
 
@@ -83,7 +84,8 @@ class EventFormDetailView(ClubStaffRequiredMixin, DetailView):
 
 
 def notify_api_error(request, error: HelloAssoApiError):
-    messages.error(request, f"Échec du rafraîchissement : {error}")
+    logger.error("HelloAsso API error: %s", error)
+    messages.error(request, "Échec de la communication avec HelloAsso. Veuillez réessayer.")
 
 
 @admin_required
@@ -381,6 +383,8 @@ def membership_form_detail(request, form_slug):
 
 @admin_required
 def refresh_membership_forms(request):
+    if request.method != 'POST':
+        return redirect('saison-formulaires')
     api = get_hello_asso_api()
     try:
         count = api.refresh_membership_forms()
@@ -788,9 +792,12 @@ def adherent_formation_export(request, pk, cursus_pk):
     doc.build(story)
 
     buf.seek(0)
-    filename = f"evaluation_{member.last_name}_{member.first_name}_{cursus.name}.pdf"
+    raw_name = f"evaluation_{member.last_name}_{member.first_name}_{cursus.name}.pdf"
+    safe_ascii = raw_name.replace('"', '').replace('\n', '').replace('\r', '')
     response = HttpResponse(buf, content_type='application/pdf')
-    response['Content-Disposition'] = f'attachment; filename="{filename}"'
+    response['Content-Disposition'] = (
+        f"attachment; filename=\"{safe_ascii}\"; filename*=UTF-8''{quote(raw_name)}"
+    )
     return response
 
 
@@ -843,7 +850,8 @@ def create_event_form(request):
                 messages.success(request, f"Sortie « {d['title']} » créée avec succès.")
                 return redirect('inscriptions')
             except HelloAssoApiError as e:
-                messages.error(request, f"Échec de la création : {e}")
+                logger.error("HelloAsso API error (create_event_form): %s", e)
+                messages.error(request, "Échec de la création de la sortie. Veuillez réessayer.")
     else:
         form = EventFormCreateForm()
     return render(request, 'helloAssoImporter/event_form_create.html', {'form': form})
@@ -855,6 +863,8 @@ _REFRESH_COOLDOWN_SECONDS = 60
 
 @club_staff_required
 def refresh_event_forms(request):
+    if request.method != 'POST':
+        return redirect('inscriptions')
     if cache.get(_REFRESH_COOLDOWN_KEY):
         messages.warning(request, "Rafraîchissement déjà effectué récemment. Veuillez patienter 1 minute.")
         return redirect('inscriptions')


### PR DESCRIPTION
## Résumé

Correction de trois vulnérabilités HIGH identifiées lors de l'analyse de sécurité.

- **H1 — CSRF via GET sur les endpoints refresh** : Les vues `refresh_membership_forms` et `refresh_event_forms` acceptaient des requêtes GET, permettant à n'importe quelle page externe de déclencher un import complet. Les vues rejettent maintenant tout appel non-POST, et les boutons "Rafraîchir" sont convertis en `<form method="post">` avec `{% csrf_token %}`.

- **H2 — Injection d'en-tête HTTP via Content-Disposition** : Le nom de fichier du PDF d'évaluation était construit directement depuis des données utilisateur (nom, prénom, cursus) sans sanitisation. Les caractères de contrôle (`"`, `\n`, `\r`) sont maintenant supprimés, et le paramètre `filename*` (RFC 5987) est ajouté via `urllib.parse.quote`.

- **H3 — Fuite d'erreurs API brutes vers les utilisateurs** : `str(ApiException)` (corps HTTP brut, potentiellement avec des détails internes) était affiché directement dans les flash messages. Les erreurs sont maintenant loguées côté serveur et un message générique est affiché à l'utilisateur.

## Fichiers modifiés

- `helloAssoImporter/views.py`
- `helloAssoImporter/templates/helloAssoImporter/membership_forms.html`
- `helloAssoImporter/templates/helloAssoImporter/event_forms.html`